### PR TITLE
Add endianess to architectures, use it in mpt formats

### DIFF
--- a/src/arch/power.h
+++ b/src/arch/power.h
@@ -35,6 +35,7 @@ struct ArchPower : public Arch {
     std::vector<std::string> prefix() const {
         return {"powerpc64", "powerpc64le", "ppc64", "ppc64le"};
     }
+    Endianess get_endianess() const {return Endianess::LITTLE;}
 
     void parse_inst(Instruction &) const;
 

--- a/src/arch/riscv.h
+++ b/src/arch/riscv.h
@@ -14,6 +14,7 @@ struct ArchRiscV : public Arch {
     std::vector<std::string> prefix() const {
         return {"riscv64"};
     }
+    Endianess get_endianess() const {return Endianess::LITTLE;}
 
     void parse_inst(Instruction &) const;
 

--- a/src/arch/sysz.h
+++ b/src/arch/sysz.h
@@ -33,6 +33,7 @@ namespace chopstix {
 struct ArchZ : public Arch {
     std::string name() const { return "SystemZ"; }
     std::vector<std::string> prefix() const { return {"s390", "s360"}; }
+    Endianess get_endianess() const {return Endianess::LITTLE;}
 
     void parse_inst(Instruction &) const;
 

--- a/src/arch/x86.h
+++ b/src/arch/x86.h
@@ -33,6 +33,7 @@ namespace chopstix {
 struct ArchX86 : public Arch {
     std::string name() const { return "x86"; }
     std::vector<std::string> prefix() const { return {"x86", "x86_64"}; }
+    Endianess get_endianess() const {return Endianess::LITTLE;}
 
     void parse_inst(Instruction &) const;
 

--- a/src/client/text.cpp
+++ b/src/client/text.cpp
@@ -50,7 +50,12 @@ std::unique_ptr<TextFormat> get_format() {
     auto opt = Option::get("fmt").as_string("text");
     if (opt == "text") return format(new TextFormat());
     if (opt == "annotate") return format(new AnnotFormat());
-    if (opt == "mpt") return format(new MptFormat());
+    if (opt == "mpt") {
+        auto opt_arch = Option::get("arch");
+        CHECK_USAGE(text, opt_arch.is_set(), "No architecture specified");
+        auto arch = Arch::get_impl(opt_arch.as_string());
+        return format(new MptFormat(arch->get_endianess()));
+    }
     CHECK_USAGE(text, 0, "Unknown format '{}'", opt);
 }
 

--- a/src/client/text_format.cpp
+++ b/src/client/text_format.cpp
@@ -164,8 +164,8 @@ std::string invert_mpt(std::string raw) {
 std::ostream &MptFormat::format(std::ostream &os, const Instruction &inst) {
     auto text = inst.text;
     std::replace(text.begin(), text.end(), '%', '$');
-    // TODO Check arch
-    fmt::print(os, "    0x{} ; {}\n", inst.raw_be(), text);
+    auto raw = (endianess == Endianess::LITTLE ? inst.raw : inst.raw_be());
+    fmt::print(os, "    0x{} ; {}\n", raw, text);
     return os;
 }
 

--- a/src/client/text_format.h
+++ b/src/client/text_format.h
@@ -52,12 +52,17 @@ struct AnnotFormat : TextFormat {
 };
 
 struct MptFormat : TextFormat {
+    MptFormat(Endianess endianess) : endianess(endianess) {}
+
     virtual std::ostream &header(std::ostream &os);
     virtual std::ostream &format(std::ostream &os, const Module &module);
     virtual std::ostream &format(std::ostream &os, const Function &func);
     virtual std::ostream &format(std::ostream &os, const BasicBlock &block);
     virtual std::ostream &format(std::ostream &os, const Instruction &inst);
     virtual std::ostream &format(std::ostream &os, const Path &path);
+
+private:
+    Endianess endianess;
 };
 
 };  // namespace chopstix

--- a/src/client/usage/text
+++ b/src/client/usage/text
@@ -15,3 +15,4 @@ Options:
                      text      Just plain text.
                      annotate  Text with annotation (i.e. score).
                      mpt       Output as Microprobe test file (.mpt).
+  -arch <arch>    Name of the Architecture to generate the mpt for

--- a/src/core/arch.h
+++ b/src/core/arch.h
@@ -43,6 +43,11 @@ namespace chopstix {
 
 struct Instruction;
 
+enum class Endianess {
+    LITTLE,
+    BIG
+};
+
 struct Arch {
     using regbuf_type = long *;
     using impl_ptr = std::unique_ptr<Arch>;
@@ -55,6 +60,7 @@ struct Arch {
     virtual void parse_inst(Instruction &) const = 0;
     virtual std::string name() const = 0;
     virtual std::vector<std::string> prefix() const = 0;
+    virtual Endianess get_endianess() const = 0;
 
     virtual size_t regsize() const = 0;
     regbuf_type create_regs() const { return new long[regsize()]; }


### PR DESCRIPTION
This PR adds the concept of "Endianess" to architectures, which is used in the mpt text format generation to determine how the raw instructions should be written (i.e. Little or Big Endian).