### PR TITLE
Fix breakpoints leaking into other instructions

### DIFF
--- a/src/arch/riscv.h
+++ b/src/arch/riscv.h
@@ -32,6 +32,10 @@ struct ArchRiscV : public Arch {
     long parse_syscall(regbuf_type regs) const;
     long parse_ret(regbuf_type regs) const;
     void parse_args(regbuf_type regs, regbuf_type args) const;
+protected:
+    BreakpointSize get_breakpoint_size() const {
+        return BreakpointSize::HALF_WORD;
+    }
 };
 
 }  // namespace chopstix

--- a/src/core/arch.cpp
+++ b/src/core/arch.cpp
@@ -32,6 +32,7 @@
 #include "support/string.h"
 
 #include <sys/utsname.h>
+#include <byteswap.h>
 
 #if defined(CHOPSTIX_POWER_SUPPORT) || defined(CHOPSTIX_POWERLE_SUPPORT)
 #include "arch/power.h"
@@ -109,4 +110,24 @@ Popen Arch::objdump(const std::string &filename) const {
 
     std::string run = fmt::format("{} -j .text -d {}", cmd, filename);
     return Popen(run);
+}
+
+long Arch::get_breakpoint_mask() const {
+    long mask;
+    switch(get_breakpoint_size()) {
+        case BreakpointSize::HALF_WORD:
+            mask = std::numeric_limits<unsigned short>::max();
+            break;
+        case BreakpointSize::WORD:
+            mask = std::numeric_limits<unsigned int>::max();
+            break;
+        default:
+        case BreakpointSize::DOUBLE_WORD:
+            mask = std::numeric_limits<unsigned long>::max();
+            break;
+    }
+
+    if (get_endianess() == Endianess::BIG) mask = __bswap_64(mask);
+
+    return ~mask;
 }

--- a/src/core/arch.h
+++ b/src/core/arch.h
@@ -38,6 +38,7 @@
 #include <ostream>
 #include <string>
 #include <vector>
+#include <limits>
 
 namespace chopstix {
 
@@ -46,6 +47,12 @@ struct Instruction;
 enum class Endianess {
     LITTLE,
     BIG
+};
+
+enum class BreakpointSize {
+    HALF_WORD,
+    WORD,
+    DOUBLE_WORD,
 };
 
 struct Arch {
@@ -61,6 +68,7 @@ struct Arch {
     virtual std::string name() const = 0;
     virtual std::vector<std::string> prefix() const = 0;
     virtual Endianess get_endianess() const = 0;
+    virtual long get_breakpoint_mask() const;
 
     virtual size_t regsize() const = 0;
     regbuf_type create_regs() const { return new long[regsize()]; }
@@ -83,6 +91,11 @@ struct Arch {
     virtual long parse_syscall(regbuf_type regs) const = 0;
     virtual long parse_ret(regbuf_type regs) const = 0;
     virtual void parse_args(regbuf_type regs, regbuf_type args) const = 0;
+
+protected:
+    virtual BreakpointSize get_breakpoint_size() const {
+        return BreakpointSize::DOUBLE_WORD;
+    }
 };
 
 }  // namespace chopstix

--- a/src/core/process.cpp
+++ b/src/core/process.cpp
@@ -26,6 +26,7 @@
 
 #include "process.h"
 
+#include "core/arch.h"
 #include "support/check.h"
 #include "support/log.h"
 
@@ -196,8 +197,12 @@ void Process::step(int sig) {
 void Process::set_break(long addr) {
     log::debug("set break at %x", addr);
     auto it = breaks_.find(addr);
-    if (it == breaks_.end()) breaks_[addr] = peek(addr);
-    poke(addr, 0);
+    long addr_content = peek(addr);
+    if (it == breaks_.end()) breaks_[addr] = addr_content;
+    long mask = Arch::current()->get_breakpoint_mask();
+    addr_content &= mask;
+    log::debug("break contents are %x", addr_content);
+    poke(addr, addr_content);
 }
 
 void Process::remove_break(long addr) {

--- a/src/core/tracer/tracer.cpp
+++ b/src/core/tracer/tracer.cpp
@@ -67,7 +67,8 @@ void Tracer::stop() {
 }
 
 void Tracer::set_state(TracerState *state) {
-    log::verbose("State change");
+    log::verbose("State change at PC = 0x%x",
+                 Arch::current()->get_pc(child.pid()));
 
     if (current_state != nullptr) current_state->on_state_finish(child);
     state->on_state_start(child);

--- a/src/trace/memory.cpp
+++ b/src/trace/memory.cpp
@@ -457,6 +457,8 @@ void Memory::protect_region(mem_region *reg) {
 
     check(!err, "Unable to protect region %x-%x %s %s", reg->addr[0],
           reg->addr[1], reg->perm, reg->path);
+    log::debug("Memory::protect_region: protected %d bytes at %x",
+               REGION_SIZE(reg), reg->addr[0]);
 }
 
 void Memory::unprotect_region(mem_region *reg) {
@@ -507,6 +509,8 @@ void Memory::unprotect_page(mem_region *reg, unsigned long page_addr) {
                       decode_perm(reg->perm));
     check(!err, "Unable to unprotect page %x in region %x-%x %s %s", page_addr,
           reg->addr[0], reg->addr[1], reg->perm, reg->path);
+    log::debug("Memory::unprotect_page: unprotected %d bytes at %x", pagesize_,
+               page_addr);
 }
 
 void Memory::debug_all() {


### PR DESCRIPTION
This PR fixes breakpoints leaking into other instructions, resulting in the tracing to finish sooner than expected.

Up until these changes, breakpoints were 8 bytes long. In some architectures, such as RISC-V, this is not good as it spans multiple instructions, resulting in traps being placed in other places other than the ones indicated.

Here is an example, imagine a binary which uses 16 bit instructions and has the following code:

```asm

function_a:
    add x0, x1, x2;
    jmp loop;
    add x0, x1, x2;
    ret
loop:
    add x1, x1, x2;
    bne x1, x0, loop;
```

It is intuitive to think that if we write more than 2 bytes at the address of the `ret` instruction, the trap will "leak" into the next instruction (the beginning of a loop) thus stopping execution sooner than one would expect.

To address this issue, each architecture can now define the size of the breakpoint to use (ranging from half word to double word, the maximum breakpoint size supported by the system at the moment). By default the breakpoint size will be the same as until now, 8 bytes (i.e. double word).

I suspect the PowerPC architecture will also benefit from this changes, but the adequate breakpoint size has to be chosen and I'm not knowledgeable enough about PowerPC to make that decision.