### PR TITLE
Change most libc calls during tracing to syscalls

### DIFF
--- a/src/core/process.cpp
+++ b/src/core/process.cpp
@@ -30,8 +30,8 @@
 #include "support/check.h"
 #include "support/log.h"
 
-#include <bits/types/siginfo_t.h>
 #include <sys/ptrace.h>
+#include <sys/signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>

--- a/src/core/process.cpp
+++ b/src/core/process.cpp
@@ -30,6 +30,7 @@
 #include "support/check.h"
 #include "support/log.h"
 
+#include <bits/types/siginfo_t.h>
 #include <sys/ptrace.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -162,19 +163,23 @@ int Process::stop_sig() { return WSTOPSIG(status_); }
 void Process::send(int sig) { kill(pid_, sig); }
 void Process::syscall(int sig) {
     status_ = 0;
+    log::debug("process::syscall");
     long ret = ptrace(PTRACE_SYSCALL, pid_, 0, sig);
     check(ret != -1, "ptrace_syscall");
 }
 void Process::cont(int sig) {
     status_ = 0;
+    log::debug("process::cont");
     long ret = ptrace(PTRACE_CONT, pid_, 0, sig);
     check(ret != -1, "ptrace_cont");
 }
 void Process::attach() {
+    log::debug("process::attach");
     long ret = ptrace(PTRACE_ATTACH, pid_, 0, 0);
     check(ret != -1, "ptrace_attach");
 }
 void Process::detach(int sig) {
+    log::debug("process::detach");
     long ret = ptrace(PTRACE_DETACH, pid_, 0, sig);
     check(ret != -1, "ptrace_detach");
 }
@@ -190,6 +195,7 @@ void Process::poke(long addr, long data) {
 }
 
 void Process::step(int sig) {
+    log::debug("process::step");
     long ret = ptrace(PTRACE_SINGLESTEP, pid_, 0, sig);
     check(ret != -1, "ptrace_singlestep");
 }
@@ -209,6 +215,13 @@ void Process::remove_break(long addr) {
     log::debug("remove break at %x", addr);
     auto it = breaks_.find(addr);
     if (it != breaks_.end()) poke(addr, it->second);
+}
+
+void *Process::get_segfault_addr() {
+    siginfo_t siginfo;
+    long ret = ptrace(PTRACE_GETSIGINFO, pid_, NULL, &siginfo);
+    check(ret != -1, "ptrace_getsiginfo");
+    return siginfo.si_addr;
 }
 
 void Process::dyn_call(long addr, Arch::regbuf_type &regs, long sp, std::vector<unsigned long> &args) {
@@ -234,6 +247,9 @@ void Process::dyn_call(long addr, Arch::regbuf_type &regs, long sp, std::vector<
             // should be just skipped since it is as a result of our tracing
             // library code and not from the application code.
 
+            log::debug("Segfault info: PC = %x, RA = %x, ADDR = %x",
+                       Arch::current()->get_pc(pid()),
+                       Arch::current()->get_lnk(pid()), get_segfault_addr());
             log::debug(
                 "Process::dyn_call: Ignoring segmentation fault during dynamic "
                 "call");

--- a/src/core/process.h
+++ b/src/core/process.h
@@ -112,6 +112,8 @@ class Process {
         return infos;
     }
 
+    void *get_segfault_addr();
+
   private:
     int pid_;
     int status_;

--- a/src/core/tracer/regionofinterest.cpp
+++ b/src/core/tracer/regionofinterest.cpp
@@ -31,10 +31,14 @@ void TracerRegionOfInterestState::on_state_start(Process &child) {
 
 void TracerRegionOfInterestState::handle_signal(Process &child, int signal) {
     if (signal == SIGSEGV) {
-        // forward signal
         log::debug("RegionOfInterest:: catching signal SIGSEGV");
+        log::debug("Segfault info: PC = %x, RA = %x, ADDR = %x",
+                   Arch::current()->get_pc(child.pid()),
+                   Arch::current()->get_lnk(child.pid()),
+                   child.get_segfault_addr());
         tracer->save_page();
 
+        // forward signal
         log::debug("RegionOfInterest:: forward signal SIGSEGV");
         child.syscall(signal);
     } else if (signal == SIGTRAP) {

--- a/src/support/log.h
+++ b/src/support/log.h
@@ -61,7 +61,7 @@ struct Logger {
         if (m > mode_) return;
         n = sfmt::format(linebuf, sizeof(linebuf), "%s %s: ", LOG_FROM,
                          prefix[m]);
-        ssize_t w = write(fd_, linebuf, n);
+        ssize_t w = syscall(SYS_write, fd_, linebuf, n);
         assert(w == n && "Write errror");
         n = sfmt::format(linebuf, sizeof(linebuf), fmt, args...);
         linebuf[n++] = '\n';


### PR DESCRIPTION
Because libc is protected during tracing, its functions are not accessible. Using them results in a segmentation fault within the tracing helper library (libcxtrace).

To get around this, the code doesn't use any libc functions. However, some functions were still being called; most notably those related to syscalls (file read, write, seek, etc). This PR changes those left over calls to libc functions to direct syscalls which skip libc.

Some additional debugging functions & logs were left active on purpose, in case this issue appears again in the future (i.e. I missed some function calls).