### PR TITLE
Fix wrong permissions after protecting a read-execute page

### DIFF
--- a/src/trace/memory.cpp
+++ b/src/trace/memory.cpp
@@ -47,7 +47,7 @@ static int protect_bits_R = PROT_NONE;    // Read-only (contains GOT :S)
 static int protect_bits_W = PROT_NONE;    // Should never happen
 static int protect_bits_X = PROT_NONE;    // Should never happen
 static int protect_bits_RW = PROT_NONE;   // Data section
-static int protect_bits_RX = PROT_READ;   // Text section
+static int protect_bits_RX = PROT_NONE;   // Text section
 static int protect_bits_WX = PROT_NONE;   // Should never happen
 static int protect_bits_RWX = PROT_READ;  // Might happen?
 


### PR DESCRIPTION
Pages within the `.text` section have read-execute permissions. After calling the relevant functions, the tracing library protects those pages only from execution, i.e. they still have read permissions. This causes read accesses to these pages to go unnoticed by the tracer and thus the memory dumps end up with missing pages.

This PR changes the page protection system to remove all permissions from read-execute regions, instead of removing only the execute permission.