### PR TITLE
[POWER] Implement argument passing for dynamic calls

### DIFF
--- a/src/arch/power.cpp
+++ b/src/arch/power.cpp
@@ -215,5 +215,11 @@ void ArchPower::parse_args(regbuf_type regs, regbuf_type args) const {
 }
 
 void ArchPower::set_args(pid_t pid, std::vector<unsigned long> &args) const {
-    failx("Not implemented");
+    check(args.size() <= 8, "Cannot set more than 8 argument registers.");
+    long buf[POWER_NUM_REGS];
+    read_regs(pid, buf);
+    for (size_t i = 0; i < args.size(); i++) {
+        buf[3 + i] = args[i];
+    }
+    write_regs(pid, buf);
 }


### PR DESCRIPTION
This PR brings the POWER implementation up to par compared to RISC-V's.

The only new architecture-specific feature is the passing of arguments during a dynamic call to the tracee, which this PR implements for the POWER ISA. The logic is the same as RISC-V's implementation, it sets the contents of registers R3 to R10.