### PR TITLE
Fix chop-marks-riscv

### DIFF
--- a/tools/chop-marks-riscv
+++ b/tools/chop-marks-riscv
@@ -6,10 +6,10 @@ EXECUTABLE=$1
 FUNCTION=$2
 
 find_ret_address () {
-    objdump --disassemble="$1" "$EXECUTABLE" | grep "ret" | cut -d":" -f 1 | awk '{ printf "%s%s", sep, $0 ; sep="," } END { print "" }' | tr -d ' '
+    objdump --disassemble="$1" "$EXECUTABLE" | grep -w "ret" | cut -d":" -f 1 | awk '{ printf "%s%s", sep, $0 ; sep="," } END { print "" }' | tr -d ' '
 }
 
-BEGIN=$(objdump --disassemble="$FUNCTION" "$EXECUTABLE" | grep "$FUNCTION" -m 1 | cut -d" " -f 1)
+BEGIN=$(nm "$EXECUTABLE" | grep -w "$FUNCTION" -m 1 | cut -d" " -f 1)
 END=$(find_ret_address "$FUNCTION")
 
 if [ -z "$END" ]


### PR DESCRIPTION
- Fix script not working properly when the binary contains the name of
  the function
- Fix script not working properly when the name of the function contains "ret"